### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See also the [ExampleProject]
 ## Requirements
 
 * iOS 8.0+
-* XCode 7.0+
+* Xcode 7.0+
 
 ## Installation
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
